### PR TITLE
Update RSVP wording and add reservation disclaimer on 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -40,6 +40,9 @@
       --input: 214.3 31.8% 91.4%;
       --ring: 222.2 84% 4.9%;
       --radius: 0.5rem;
+      --warning-bg: 38 92% 95%;
+      --warning-border: 32 95% 44%;
+      --warning-text: 24 9.8% 10%;
     }
 
     * {
@@ -284,6 +287,21 @@
       color: hsl(var(--foreground));
     }
 
+    .reservation-note {
+      margin: 0 0 1.25rem 0;
+      padding: 0.875rem 1rem;
+      border: 1px solid hsl(var(--warning-border) / 0.35);
+      background-color: hsl(var(--warning-bg));
+      border-radius: var(--radius);
+      color: hsl(var(--warning-text));
+      font-size: 0.95rem;
+      line-height: 1.6;
+    }
+
+    .reservation-note strong {
+      font-weight: 600;
+    }
+
     .limited-seats {
       display: flex;
       align-items: center;
@@ -503,8 +521,13 @@
     <div class="rsvp-container" id="rsvp-container">
       <div class="limited-seats">
         <h2>Let us know you're coming!</h2>
-        <div><i class="fas fa-users"></i> Limited seats</div>
+        <div><i class="fas fa-users"></i> First come, first served</div>
       </div>
+
+      <p class="reservation-note">
+        <strong>Please note:</strong> This is not a reservation. We do not accept reservations at our South Creek location, and seating is first come, first served.
+      </p>
+
       <p><strong>Are you attending this event?</strong></p>
       <div class="attendance-options">
         <input type="radio" id="attend-yes" name="attendance" value="yes" checked>
@@ -518,7 +541,7 @@
       <input type="text" id="name" placeholder="Enter your name">
       <label class="rsvp-label" for="email">Email</label>
       <input type="email" id="email" placeholder="Enter your email">
-      <button class="register-button" type="submit" id="register-btn">Register</button>
+      <button class="register-button" type="submit" id="register-btn">Submit</button>
     </div>
   </div>
 
@@ -802,11 +825,11 @@ END:VCALENDAR`;
           const eventName = document.getElementById('event-title')?.textContent || 'the event';
           let message = '';
           if (attendance === 'yes') {
-            message = `You are attending ${eventName}!`;
+            message = `Thanks for letting us know you're coming to ${eventName}. Please note this is not a reservation. We do not accept reservations at our South Creek location, and seating is first come, first served.`;
           } else if (attendance === 'maybe') {
-            message = `You're interested in ${eventName}.`;
+            message = `Thanks for letting us know you're interested in ${eventName}. Please note this is not a reservation. We do not accept reservations at our South Creek location, and seating is first come, first served.`;
           } else if (attendance === 'no') {
-            message = `You are not attending ${eventName}.`;
+            message = `Thanks for letting us know you can't make ${eventName}.`;
           }
     
           // Fade out RSVP form and replace with success message
@@ -821,7 +844,7 @@ END:VCALENDAR`;
           // Show error on button if response not OK
           registerBtn.textContent = 'Error';
           setTimeout(() => {
-            registerBtn.textContent = 'Register';
+            registerBtn.textContent = 'Submit';
             registerBtn.disabled = false;
           }, 2000);
         }
@@ -829,7 +852,7 @@ END:VCALENDAR`;
         console.error('Error submitting RSVP:', error);
         registerBtn.textContent = 'Error';
         setTimeout(() => {
-          registerBtn.textContent = 'Register';
+          registerBtn.textContent = 'Submit';
           registerBtn.disabled = false;
         }, 2000);
       }


### PR DESCRIPTION
### Motivation
- Surface a clear no-reservations policy for the South Creek location and make RSVP expectations explicit to users. 
- Improve RSVP copy and button labeling for clarity and consistency across the form and success/error flows. 
- Provide a visually distinct notice for reservation guidance using dedicated warning color tokens.

### Description
- Added CSS variables `--warning-bg`, `--warning-border`, and `--warning-text` and a new `.reservation-note` style block to present reservation guidance. 
- Replaced the small “Limited seats” label with “First come, first served” and inserted a styled reservation disclaimer paragraph into the RSVP section. 
- Changed the RSVP button text from `Register` to `Submit` and updated the JS success messages for `yes`/`maybe` to include the no-reservation/first-come-first-served notice, and adjusted error-reset text to return to `Submit`.

### Testing
- Ran `rg -n "warning-bg|reservation-note|First come, first served|id=\"register-btn\">Submit|Thanks for letting us know" 404.html` to verify the expected tokens and copy were present, which succeeded. 
- Served the site locally with `python3 -m http.server 4173` for visual verification, which started successfully. 
- Captured a full-page Playwright screenshot of `http://127.0.0.1:4173/404.html` to validate the visual changes, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1cf65e120832a9f7d31a0cc0aa0c7)