### PR TITLE
Add first-come-first-served notice and adjust RSVP UI/logic on event page

### DIFF
--- a/404.html
+++ b/404.html
@@ -40,6 +40,9 @@
       --input: 214.3 31.8% 91.4%;
       --ring: 222.2 84% 4.9%;
       --radius: 0.5rem;
+      --warning-bg: 38 92% 95%;
+      --warning-border: 32 95% 44%;
+      --warning-text: 24 9.8% 10%;
     }
 
     * {
@@ -284,6 +287,21 @@
       color: hsl(var(--foreground));
     }
 
+    .reservation-note {
+      margin: 0 0 1.25rem 0;
+      padding: 0.875rem 1rem;
+      border: 1px solid hsl(var(--warning-border) / 0.35);
+      background-color: hsl(var(--warning-bg));
+      border-radius: var(--radius);
+      color: hsl(var(--warning-text));
+      font-size: 0.95rem;
+      line-height: 1.6;
+    }
+
+    .reservation-note strong {
+      font-weight: 600;
+    }
+
     .limited-seats {
       display: flex;
       align-items: center;
@@ -503,8 +521,13 @@
     <div class="rsvp-container" id="rsvp-container">
       <div class="limited-seats">
         <h2>Let us know you're coming!</h2>
-        <div><i class="fas fa-users"></i> Limited seats</div>
+        <div><i class="fas fa-users"></i> First come, first served</div>
       </div>
+
+      <p class="reservation-note">
+        <strong>Please note:</strong> This is not a reservation. We do not accept reservations at our South Creek location, and seating is first come, first served.
+      </p>
+
       <p><strong>Are you attending this event?</strong></p>
       <div class="attendance-options">
         <input type="radio" id="attend-yes" name="attendance" value="yes" checked>
@@ -518,7 +541,7 @@
       <input type="text" id="name" placeholder="Enter your name">
       <label class="rsvp-label" for="email">Email</label>
       <input type="email" id="email" placeholder="Enter your email">
-      <button class="register-button" type="submit" id="register-btn">Register</button>
+      <button class="register-button" type="submit" id="register-btn">Submit</button>
     </div>
   </div>
 
@@ -740,10 +763,11 @@ END:VCALENDAR`;
         document.getElementById('office365-link').href = urls.office365;
         document.getElementById('event-details').style.display = 'block';
         document.getElementById('not-found').style.display = 'none';
-        if (event.tock === true) {
-        document.getElementById('rsvp-container').style.display = 'none';
-      } else {
-        document.getElementById('rsvp-container').style.display = 'block';
+        const hasTockLink = typeof event.tockLink === 'string' && event.tockLink.trim().length > 0;
+        if (event.tock === true || hasTockLink) {
+          document.getElementById('rsvp-container').style.display = 'none';
+        } else {
+          document.getElementById('rsvp-container').style.display = 'block';
         }
       } catch (error) {
         console.error('Error fetching event data:', error);
@@ -802,11 +826,11 @@ END:VCALENDAR`;
           const eventName = document.getElementById('event-title')?.textContent || 'the event';
           let message = '';
           if (attendance === 'yes') {
-            message = `You are attending ${eventName}!`;
+            message = `Thanks for letting us know you're coming to ${eventName}. Please note this is not a reservation. We do not accept reservations at our South Creek location, and seating is first come, first served.`;
           } else if (attendance === 'maybe') {
-            message = `You're interested in ${eventName}.`;
+            message = `Thanks for letting us know you're interested in ${eventName}. Please note this is not a reservation. We do not accept reservations at our South Creek location, and seating is first come, first served.`;
           } else if (attendance === 'no') {
-            message = `You are not attending ${eventName}.`;
+            message = `Thanks for letting us know you can't make ${eventName}.`;
           }
     
           // Fade out RSVP form and replace with success message
@@ -821,7 +845,7 @@ END:VCALENDAR`;
           // Show error on button if response not OK
           registerBtn.textContent = 'Error';
           setTimeout(() => {
-            registerBtn.textContent = 'Register';
+            registerBtn.textContent = 'Submit';
             registerBtn.disabled = false;
           }, 2000);
         }
@@ -829,7 +853,7 @@ END:VCALENDAR`;
         console.error('Error submitting RSVP:', error);
         registerBtn.textContent = 'Error';
         setTimeout(() => {
-          registerBtn.textContent = 'Register';
+          registerBtn.textContent = 'Submit';
           registerBtn.disabled = false;
         }, 2000);
       }


### PR DESCRIPTION
### Motivation
- Clarify that RSVPs do not constitute reservations for the South Creek location and make RSVP UI copy explicit about first-come-first-served seating.

### Description
- Add warning color CSS variables (`--warning-bg`, `--warning-border`, `--warning-text`) and styles for a new `.reservation-note` element. 
- Insert a reservation notice paragraph inside the RSVP container and change the limited-seats label from "Limited seats" to "First come, first served". 
- Rename the RSVP button text from `Register` to `Submit` and update failure recovery text to restore `Submit`. 
- Update RSVP submission feedback to include the non-reservation note for `yes` and `maybe` responses and change the success messaging accordingly. 
- Change the RSVP visibility logic to hide the form when `event.tock === true` or when `event.tockLink` is a non-empty string.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1cf65e120832a9f7d31a0cc0aa0c7)